### PR TITLE
Compatible with Powershell 5.1

### DIFF
--- a/Remove-Docker.ps1
+++ b/Remove-Docker.ps1
@@ -1,7 +1,7 @@
 #Requires -RunAsAdministrator
 
 Stop-Service Docker
-Remove-Service Docker
+sc.exe delete Docker
 Remove-Item "$env:ProgramFiles\Docker" -Force -Recurse
 Remove-Item "$env:ProgramFiles\Linux Containers" -Force -Recurse
 Remove-LocalGroup -Name Docker

--- a/Update-Docker.ps1
+++ b/Update-Docker.ps1
@@ -4,7 +4,7 @@
 
 if (Get-Service Docker -ErrorAction SilentlyContinue) {
     Stop-Service Docker
-    Remove-Service Docker
+    sc.exe delete Docker
     Remove-Item "$env:ProgramFiles\Docker" -Force -Recurse
 }
 else {


### PR DESCRIPTION
`Remove-Services` is not available in the built-in Powershell 5.1 according to https://github.com/MicrosoftDocs/PowerShell-Docs/issues/3775.